### PR TITLE
Leave MDI out of bootstrap

### DIFF
--- a/bootstrap5/bootstrap.ur
+++ b/bootstrap5/bootstrap.ur
@@ -644,8 +644,6 @@ style icon_bar
 style  mb_0
 style  px_0
 style  pb_0
-style  mdi
-style  mdi_send
 style  m_2
 style  ms_0
 style  ms_2


### PR DESCRIPTION
This was added in error.  Material Design Icons aren't a part of bootstrap and should be separate.